### PR TITLE
link the workflow to the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ URL to the luacheckrc configuration file to be used during checking.
 For current luacheckrc to use with factorio I recommend [Nexela/Factorio-luacheckrc](https://github.com/Nexela/Factorio-luacheckrc)
 
 [release status]: https://github.com/Roang-zero1/factorio-mod-luacheck/workflows/Check%20&%20Release/badge.svg
-[release workflow]: https://github.com/Roang-zero1/factorio-mod-luacheck/actions?query=workflow%3A%22Check+%26+Release%22
+[release workflow]: https://github.com/Roang-zero1/factorio-mod-luacheck/actions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Action for luacheck
 
-![](https://github.com/Roang-zero1/factorio-mod-luacheck/workflows/Check%20&%20Release/badge.svg)
+[![release badge][release status]][release workflow]
 
 This action will run your mod code through [luacheck](https://github.com/mpeterv/luacheck).
 
@@ -38,3 +38,6 @@ URL to the luacheckrc configuration file to be used during checking.
 ## Recommended luacheckrc
 
 For current luacheckrc to use with factorio I recommend [Nexela/Factorio-luacheckrc](https://github.com/Nexela/Factorio-luacheckrc)
+
+[release status]: https://github.com/Roang-zero1/factorio-mod-luacheck/workflows/Check%20&%20Release/badge.svg
+[release workflow]: https://github.com/Roang-zero1/factorio-mod-luacheck/actions?query=workflow%3A%22Check+%26+Release%22


### PR DESCRIPTION
If the badge is clicked it should show the workflow and not the badge itself.
Also I moved the link URLs to the end of the file to make raw README easier to read.