### PR TITLE
document usage of empty string as luacheckrc_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A sample workflow that uses this action can be found at [Roang-zero1/factorio-mo
 
 URL to the luacheckrc configuration file to be used during checking.  
 **Default**: <https://raw.githubusercontent.com/Nexela/Factorio-luacheckrc/0.17/.luacheckrc>
+If you assign an empty string "" the .luacheck file from the working tree will be used.
 
 ## Recommended luacheckrc
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: "gray-dark"
 inputs:
   luacheckrc_url:
-    description: "URL to the luacheckrc configuration file to be used during checking."
+    description: "URL to the luacheckrc configuration file to be used during checking. Assign an empty string \"\" to use the local config."
     required: false
     default: "https://raw.githubusercontent.com/Nexela/Factorio-luacheckrc/0.17/.luacheckrc"
 runs:


### PR DESCRIPTION
This adds documentation for the usage of the empty string.
Resolves #2 